### PR TITLE
Added pyproject.toml file with build dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[build-system]
+requires = ["setuptools", "wheel", "Cython", "numpy"]


### PR DESCRIPTION
This allows tools like pip to install cython before building cycpd and
thus not create an unusable wheel